### PR TITLE
Pre-commit hooks :)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 121
+exclude = .tox,.git,venv

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+[settings]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+ - repo: https://github.com/pre-commit/pre-commit-hooks
+   rev: v4.0.1
+   hooks:
+    - id: trailing-whitespace
+    - id: mixed-line-ending
+    - id: check-added-large-files
+    - id: check-ast
+    - id: check-merge-conflict
+    - id: check-yaml
+    - id: detect-aws-credentials
+    - id: end-of-file-fixer
+    - id: detect-private-key
+ - repo: https://github.com/psf/black
+   rev: 21.6b0
+   hooks:
+    - id: black
+ - repo: https://github.com/timothycrosley/isort
+   rev: 5.9.1
+   hooks:
+    - id: isort
+ - repo: https://gitlab.com/pycqa/flake8
+   rev: 3.8.4
+   hooks:
+    - id: flake8
+      additional_dependencies: [flake8-isort]

--- a/CERWaves.py
+++ b/CERWaves.py
@@ -2,102 +2,220 @@
 
 CERWaves.py by John Dorsey.
 
-When loaded, CERWaves.py loads sample audio for easy use in testing the codec. Audio samples included in the project are in the public domain.
+When loaded, CERWaves.py loads sample audio for easy use in testing the codec. Audio samples included in the project are
+in the public domain.
 
 """
-
 
 import sys
 import wave
 
-#don't use "samples/moo8bmono44100.wav":None "samples/crickets8bmono44100.wav":None,
-sounds = {"samples/moo8bmono44100.txt":None}
-
+# don't use "samples/moo8bmono44100.wav":None "samples/crickets8bmono44100.wav":None,
+sounds = {"samples/moo8bmono44100.txt": None}
 
 
 def loadSound(filename):
-  if filename.endswith(".wav"):
-    soundFile = wave.open(filename,mode="rb")
-    result = None
-    if sys.version[0] == "3":
-      result = [int(item) for item in soundFile.readframes(2**32)]
+    if filename.endswith(".wav"):
+        soundFile = wave.open(filename, mode="rb")
+        result = None
+        if sys.version[0] == "3":
+            result = [int(item) for item in soundFile.readframes(2 ** 32)]
+        else:
+            # result = [int(ord(item)) for item in soundFile.readframes(2**32)]
+            # assert False
+            print(".wav files won't be loaded in this version of python.")
+        soundFile.close()
+        return result
+    elif filename.endswith(".raw"):
+        with open(filename, mode="rb") as soundFile:
+            result = [int(item) for item in soundFile.read(2 ** 32)][1:][::2]
+        return result
+    elif filename.endswith(".txt"):
+        return deserializeSound(filename)
     else:
-      #result = [int(ord(item)) for item in soundFile.readframes(2**32)]
-      #assert False
-      print(".wav files won't be loaded in this version of python.")
-    soundFile.close()
-    return result
-  elif filename.endswith(".raw"):
-    soundFile = open(filename,mode="rb")
-    result = None
-    result = [int(item) for item in soundFile.read(2**32)][1:][::2]
-    soundFile.close()
-    return result
-  elif filename.endswith(".txt"):
-    return deserializeSound(filename)
-  else:
-    assert False, "unsupported file type."
+        assert False, "unsupported file type."
 
 
-def serializeSound(filename,sound):
-  assert filename.endswith(".txt")
-  soundFile = open(filename,"w")
-  #soundFile.write("".join(chr(item) for item in sound))
-  soundFile.write(str(sound))
-  soundFile.close()
+def serializeSound(filename, sound):
+    assert filename.endswith(".txt")
+    with open(filename, "w") as soundFile:
+        # soundFile.write("".join(chr(item) for item in sound))
+        soundFile.write(str(sound))
 
 
 def deserializeSound(filename):
-  assert filename.endswith(".txt")
-  soundFile = open(filename,"r")
-  #soundFile.write("".join(chr(item) for item in sound))
-  result = soundFile.read(2**32)
-  soundFile.close()
-  return eval(result)
+    assert filename.endswith(".txt")
+    with open(filename, "r") as soundFile:
+        # soundFile.write("".join(chr(item) for item in sound))
+        result = soundFile.read(2 ** 32)
+    return eval(result)
 
 
-def saveSound(filename,sound):
-  assert filename.endswith(".wav")
-  soundFile = wave.open(filename,mode="wb")
-  soundFile.setnchannels(1)
-  soundFile.setsampwidth(1)
-  soundFile.setframerate(44100)
-  #soundFile.write("".join(chr(item) for item in sound))
-  for item in sound:
-    assert type(item) == int
-    assert item < 256
-    assert item >= 0
-    #soundFile.write(eval("b'"+chr(item)+"'"))
-    soundFile.writeframesraw(bytes([item]))
-  soundFile.close()
+def saveSound(filename, sound):
+    assert filename.endswith(".wav")
+    soundFile = wave.open(filename, mode="wb")
+    soundFile.setnchannels(1)
+    soundFile.setsampwidth(1)
+    soundFile.setframerate(44100)
+    # soundFile.write("".join(chr(item) for item in sound))
+    for item in sound:
+        assert type(item) == int
+        assert item < 256
+        assert item >= 0
+        # soundFile.write(eval("b'"+chr(item)+"'"))
+        soundFile.writeframesraw(bytes([item]))
+    soundFile.close()
 
 
 def validateSound(sound):
-  diffs = [0,0,0,0]
-  if not type(sound) == list:
-    return False
-  for i in range(len(sound)-1):
-    diffs[i%len(diffs)] += (sound[i] != sound[i+1])
-  #print("diff sets are " + str(diffs) + ". these numbers should all be similar.")
-  if 0 in diffs:
-    return False
-  ratios = [float(diffs[i])/float(diffs[ii]) for i in range(len(diffs)) for ii in range(i)]
-  if min(ratios) < 0.8:
-    return False
-  return True
+    diffs = [0, 0, 0, 0]
+    if type(sound) != list:
+        return False
+    for i in range(len(sound) - 1):
+        diffs[i % len(diffs)] += sound[i] != sound[i + 1]
+    # print("diff sets are " + str(diffs) + ". these numbers should all be similar.")
+    if 0 in diffs:
+        return False
+    ratios = [float(diffs[i]) / float(diffs[ii]) for i in range(len(diffs)) for ii in range(i)]
+    return min(ratios) >= 0.8
 
 
 def loadSounds():
-  for key in sounds.keys():
-    sounds[key] = loadSound(key)
+    for key in sounds.keys():
+        sounds[key] = loadSound(key)
 
-  sounds["sampleNoise"] = [128,128,127, 126, 124,113,112,89,32,16,17,14,0,1,9,8,77,78,97,201,210,203,185,183,144,101,99,96,99,124,129,156,146,149,177,181,185,184,170,160,140,110,50,55,75,125,11,123,245,254,255,255,255,254,251,236,249,237,234,221,201,145,103,96,91,115,119,144,144,145,147,149,155,165,175,185,188,193,250,230,210,205,160,50,40,35,31,31,32,39,47,88,86,82,41,13,9,8,6,5,4,4,3,3,3,4,3,2,0,1,2,4,7,17,45,23,46,36,49,62,61,65,98,127,128]
-  sounds["sampleNoise"].extend([128 for i in range(128-len(sounds["sampleNoise"]))])
-  assert len(sounds["sampleNoise"]) == 128
-  for sound in sounds.values():
-    if sound != None:
-      assert validateSound(sound)
+    sounds["sampleNoise"] = [
+        128,
+        128,
+        127,
+        126,
+        124,
+        113,
+        112,
+        89,
+        32,
+        16,
+        17,
+        14,
+        0,
+        1,
+        9,
+        8,
+        77,
+        78,
+        97,
+        201,
+        210,
+        203,
+        185,
+        183,
+        144,
+        101,
+        99,
+        96,
+        99,
+        124,
+        129,
+        156,
+        146,
+        149,
+        177,
+        181,
+        185,
+        184,
+        170,
+        160,
+        140,
+        110,
+        50,
+        55,
+        75,
+        125,
+        11,
+        123,
+        245,
+        254,
+        255,
+        255,
+        255,
+        254,
+        251,
+        236,
+        249,
+        237,
+        234,
+        221,
+        201,
+        145,
+        103,
+        96,
+        91,
+        115,
+        119,
+        144,
+        144,
+        145,
+        147,
+        149,
+        155,
+        165,
+        175,
+        185,
+        188,
+        193,
+        250,
+        230,
+        210,
+        205,
+        160,
+        50,
+        40,
+        35,
+        31,
+        31,
+        32,
+        39,
+        47,
+        88,
+        86,
+        82,
+        41,
+        13,
+        9,
+        8,
+        6,
+        5,
+        4,
+        4,
+        3,
+        3,
+        3,
+        4,
+        3,
+        2,
+        0,
+        1,
+        2,
+        4,
+        7,
+        17,
+        45,
+        23,
+        46,
+        36,
+        49,
+        62,
+        61,
+        65,
+        98,
+        127,
+        128,
+    ]
+    sounds["sampleNoise"].extend([128 for _ in range(128 - len(sounds["sampleNoise"]))])
+    assert len(sounds["sampleNoise"]) == 128
+    for sound in sounds.values():
+        if sound is not None:
+            assert validateSound(sound)
 
 
 loadSounds()
-

--- a/CodecTools.py
+++ b/CodecTools.py
@@ -2,126 +2,173 @@
 
 CodecTools.py by John Dorsey.
 
-CodecTools.py contains classes and other tools that might help make it easier to rapidly create and test codecs made from smaller codecs applied in stages.
+CodecTools.py contains classes and other tools that might help make it easier to rapidly create and test codecs made
+from smaller codecs applied in stages.
 
 """
 
-from PyGenTools import makeArr, isGen
+from PyGenTools import isGen, makeArr
 
 
 def measureIntArray(inputIntArr):
-  rectBitSize = (len(inputIntArr),len(bin(max(inputIntArr))[2:]))
-  return {"length":rectBitSize[0],"bit_depth":rectBitSize[1],"bit_area":rectBitSize[0]*rectBitSize[1]}
+    rectBitSize = (len(inputIntArr), len(bin(max(inputIntArr))[2:]))
+    return {
+        "length": rectBitSize[0],
+        "bit_depth": rectBitSize[1],
+        "bit_area": rectBitSize[0] * rectBitSize[1],
+    }
 
-def printComparison(plainData,pressData):
-  plainDataMeasures, pressDataMeasures = (measureIntArray(plainData), measureIntArray(pressData))
-  estimatedCR = float(plainDataMeasures["bit_area"])/float(pressDataMeasures["bit_area"])
-  estimatedSaving = 1.0 - 1.0/estimatedCR
-  print("CodecTools.printComparison: plainData measures " + str(plainDataMeasures) + ". pressData measures " + str(pressDataMeasures) + ". Estimated CR is " + str(estimatedCR)[:8] + ". Estimated saving rate is " + str(estimatedSaving*100.0)[:8] + "%.")
+
+def printComparison(plainData, pressData):
+    plainDataMeasures, pressDataMeasures = (
+        measureIntArray(plainData),
+        measureIntArray(pressData),
+    )
+    estimatedCR = float(plainDataMeasures["bit_area"]) / float(pressDataMeasures["bit_area"])
+    estimatedSaving = 1.0 - 1.0 / estimatedCR
+    print(
+        "CodecTools.printComparison: plainData measures "
+        + str(plainDataMeasures)
+        + ". pressData measures "
+        + str(pressDataMeasures)
+        + ". Estimated CR is "
+        + str(estimatedCR)[:8]
+        + ". Estimated saving rate is "
+        + str(estimatedSaving * 100.0)[:8]
+        + "%."
+    )
+
 
 def countTrailingZeroes(inputArr):
-  i = 0
-  while inputArr[-1-i] == 0:
-    i += 1
-  return i
-
+    i = 0
+    while inputArr[-1 - i] == 0:
+        i += 1
+    return i
 
 
 def roundTripTest(testCodec, plainData, showDetails=False):
-  #test the input testCodec on testData to make sure that it is capable of reconstructing its original input. If it isn't, print additional information before returning False.
-  if isGen(plainData):
-    plainData = makeArr(plainData)
-  if type(plainData) == list:
-    if len(plainData) == 0:
-      print("CodecTools.roundTripTest: warning: plainData is empty.")
-  pressData = testCodec.encode(plainData)
-  if isGen(pressData):
-    pressData = makeArr(pressData)
-  if type(pressData) == list:
-    if len(pressData) == 0:
-      print("CodecTools.roundTripTest: warning: pressData is empty.")
-  if showDetails:
-    printComparison(plainData,pressData)
-  reconstPlainData = testCodec.decode(pressData)
-  if isGen(reconstPlainData):
-    reconstPlainData = makeArr(reconstPlainData)
-  if type(reconstPlainData) == list:
-    if len(reconstPlainData) == 0:
-      print("CodecTools.roundTripTest: warning: reconstPlainData is empty.")
-  result = (reconstPlainData == plainData)
-  if not result:
-    print("CodecTools.roundTripTest: Test failed.")
-    print("CodecTools.roundTripTest: testData is " + str(plainData) + " and reconstData is " + str(reconstPlainData) + ". pressData is " + str(pressData) + ".")
-    if type(plainData) == list and type(reconstPlainData) == list:
-      print("CodecTools.roundTripTest: Lengths " + ("do not" if len(reconstPlainData)==len(plainData) else "") + " differ.")
-  return result
+    # test the input testCodec on testData to make sure that it is capable of reconstructing its original input. If it
+    # isn't, print additional information before returning False.
+    if isGen(plainData):
+        plainData = makeArr(plainData)
+    if type(plainData) == list and len(plainData) == 0:
+        print("CodecTools.roundTripTest: warning: plainData is empty.")
+    pressData = testCodec.encode(plainData)
+    if isGen(pressData):
+        pressData = makeArr(pressData)
+    if type(pressData) == list and len(pressData) == 0:
+        print("CodecTools.roundTripTest: warning: pressData is empty.")
+    if showDetails:
+        printComparison(plainData, pressData)
+    reconstPlainData = testCodec.decode(pressData)
+    if isGen(reconstPlainData):
+        reconstPlainData = makeArr(reconstPlainData)
+    if type(reconstPlainData) == list and len(reconstPlainData) == 0:
+        print("CodecTools.roundTripTest: warning: reconstPlainData is empty.")
+    result = reconstPlainData == plainData
+    if not result:
+        print("CodecTools.roundTripTest: Test failed.")
+        print(
+            "CodecTools.roundTripTest: testData is "
+            + str(plainData)
+            + " and reconstData is "
+            + str(reconstPlainData)
+            + ". pressData is "
+            + str(pressData)
+            + "."
+        )
+        if type(plainData) == list and type(reconstPlainData) == list:
+            print(
+                "CodecTools.roundTripTest: Lengths "
+                + ("do not" if len(reconstPlainData) == len(plainData) else "")
+                + " differ."
+            )
+    return result
 
 
 def makePlatformCodec(platCodec, mainCodec):
-  return Codec((lambda x: platCodec.encode(mainCodec.encode(platCodec.decode(x)))),(lambda x: platCodec.encode(mainCodec.decode(platCodec.decode(x)))))
+    return Codec(
+        (lambda x: platCodec.encode(mainCodec.encode(platCodec.decode(x)))),
+        (lambda x: platCodec.encode(mainCodec.decode(platCodec.decode(x)))),
+    )
 
 
-def makeChainedPairCodec(codec1,codec2):
-  return Codec((lambda x: codec2.encode(codec1.encode(x))),(lambda x: codec1.decode(codec2.decode(x))))
+def makeChainedPairCodec(codec1, codec2):
+    return Codec(
+        (lambda x: codec2.encode(codec1.encode(x))),
+        (lambda x: codec1.decode(codec2.decode(x))),
+    )
 
 
 class Codec:
-  def __init__(self,encodeFun,decodeFun,transcodeFun=None,zeroSafe=None,extraArgs=None,extraKwargs=None):
-    self.encodeFun, self.decodeFun, self.transcodeFun, self.zeroSafe = (encodeFun, decodeFun, transcodeFun, zeroSafe)
-    if not (self.encodeFun or self.decodeFun or self.transcodeFun):
-      raise ValueError("No functions for encoding, decoding, or transcoding were specified!")
-    self.extraArgs, self.extraKwargs = (extraArgs if extraArgs else [], extraKwargs if extraKwargs else {})
+    def __init__(
+        self,
+        encodeFun,
+        decodeFun,
+        transcodeFun=None,
+        zeroSafe=None,
+        extraArgs=None,
+        extraKwargs=None,
+    ):
+        self.encodeFun, self.decodeFun, self.transcodeFun, self.zeroSafe = (
+            encodeFun,
+            decodeFun,
+            transcodeFun,
+            zeroSafe,
+        )
+        if not (self.encodeFun or self.decodeFun or self.transcodeFun):
+            raise ValueError("No functions for encoding, decoding, or transcoding were specified!")
+        self.extraArgs, self.extraKwargs = extraArgs or [], extraKwargs or {}
 
-  def encode(self,data,*args,**kwargs):
-    if not (self.encodeFun or self.transcodeFun):
-      raise AttributeError("Either encodeFun or transcodeFun must be defined to decode.")
-    argsToUse = args if args else self.extraArgs #a single extra argument specified when calling Codec.encode will override ALL stored values in Codec.extraArgs.
-    kwargsToUse = kwargs if kwargs else self.extraKwargs #a single extra keyword argument specified when calling Codec.encode will override ALL stored values in Codec.extraKwargs.
-    if self.encodeFun:
-      return self.encodeFun(data,*argsToUse,**kwargsToUse)
-    else:
-      return self.transcodeFun(data,"encode",*argsToUse,**kwargsToUse)
+    def encode(self, data, *args, **kwargs):
+        if not (self.encodeFun or self.transcodeFun):
+            raise AttributeError("Either encodeFun or transcodeFun must be defined to decode.")
+        argsToUse = (
+            args or self.extraArgs
+        )  # an extra argument specified when calling Codec.encode will override ALL stored values in Codec.extraArgs.
+        kwargsToUse = (
+            kwargs or self.extraKwargs
+        )  # an extra argument specified when calling Codec.encode will override ALL stored values in Codec.extraKwargs.
+        if self.encodeFun:
+            return self.encodeFun(data, *argsToUse, **kwargsToUse)
+        else:
+            return self.transcodeFun(data, "encode", *argsToUse, **kwargsToUse)
 
-  def decode(self,data,*args,**kwargs):
-    if not (self.decodeFun or self.transcodeFun):
-      raise AttributeError("Either decodeFun or transcodeFun must be defined to decode.")
-    argsToUse = args if args else self.extraArgs
-    kwargsToUse = kwargs if kwargs else self.extraKwargs
-    if self.decodeFun:
-      return self.decodeFun(data,*argsToUse,**kwargsToUse)
-    else:
-      return self.transcodeFun(data,"decode",*argsToUse,**kwargsToUse)
+    def decode(self, data, *args, **kwargs):
+        if not (self.decodeFun or self.transcodeFun):
+            raise AttributeError("Either decodeFun or transcodeFun must be defined to decode.")
+        argsToUse = args or self.extraArgs
+        kwargsToUse = kwargs or self.extraKwargs
+        if self.decodeFun:
+            return self.decodeFun(data, *argsToUse, **kwargsToUse)
+        else:
+            return self.transcodeFun(data, "decode", *argsToUse, **kwargsToUse)
 
-  def clone(self,extraArgs=None,extraKwargs=None):
-    if self.extraArgs != [] and extraArgs != None:
-      print("CodecTools.Codec.clone: warning: some existing extraArgs will not be cloned.")
-    if self.extraKwargs != {} and extraKwargs != None:
-      print("CodecTools.Codec.clone: warning: some existing extraKwargs will not be cloned.")
-    argsToUse = extraArgs if extraArgs else self.extraArgs
-    kwargsToUse = extraKwargs if extraKwargs else self.extraKwargs
-    return Codec(self.encodeFun,self.decodeFun,transcodeFun=self.transcodeFun,zeroSafe=self.zeroSafe,extraArgs=argsToUse,extraKwargs=kwargsToUse)
-
-
-
-
-
-bitSeqToStrCodec = Codec((lambda x: "".join(str(item) for item in x)),(lambda x: [int(char) for char in x]))
-
-
-
-
-
-
-
+    def clone(self, extraArgs=None, extraKwargs=None):
+        if self.extraArgs != [] and extraArgs is not None:
+            print("CodecTools.Codec.clone: warning: some existing extraArgs will not be cloned.")
+        if self.extraKwargs != {} and extraKwargs is not None:
+            print("CodecTools.Codec.clone: warning: some existing extraKwargs will not be cloned.")
+        argsToUse = extraArgs or self.extraArgs
+        kwargsToUse = extraKwargs or self.extraKwargs
+        return Codec(
+            self.encodeFun,
+            self.decodeFun,
+            transcodeFun=self.transcodeFun,
+            zeroSafe=self.zeroSafe,
+            extraArgs=argsToUse,
+            extraKwargs=kwargsToUse,
+        )
 
 
+bitSeqToStrCodec = Codec((lambda x: "".join(str(item) for item in x)), (lambda x: [int(char) for char in x]))
+
+# tests:
 
 
-#tests:
+def get_delimited_str_codec(delimiter):
+    return Codec((lambda x: delimiter.join(x)), (lambda x: x.split(delimiter)))
 
-get_delimitedStr_codec = lambda delimiter: Codec((lambda x: delimiter.join(x)),(lambda x: x.split(delimiter)))
 
-assert get_delimitedStr_codec("&").encode(["hello","world!"]) == "hello&world!"
-assert get_delimitedStr_codec("&").decode("hello&world!") == ["hello","world!"]
-
-del get_delimitedStr_codec
+assert get_delimited_str_codec("&").encode(["hello", "world!"]) == "hello&world!"
+assert get_delimited_str_codec("&").decode("hello&world!") == ["hello", "world!"]

--- a/Codes.py
+++ b/Codes.py
@@ -2,47 +2,75 @@
 
 Codes.py by John Dorsey.
 
-Codes.py contains tools for encoding and decoding universal codes like fibonacci coding, elias gamma coding, elias delta coding, and unary coding.
+Codes.py contains tools for encoding and decoding universal codes like fibonacci coding, elias gamma coding, elias delta
+coding, and unary coding.
 
 """
 
 import CodecTools
-from PyGenTools import isGen, makeGen, makeArr, arrTakeOnly, genSkipFirst, ExhaustionError
+from PyGenTools import ExhaustionError, arrTakeOnly, genSkipFirst, makeArr, makeGen
 
 
-
-def rjustArr(inputArr,length,fillItem=0,crop=False):
-  if length < 0:
-    raise ValueError("length cannot be negative.")
-  return [fillItem for i in range(length-len(inputArr))] + (([] if length == 0 else ([inputArr[-1]] if length == 1 else inputArr[-length:])) if crop else inputArr)
-
-def unwrapArr(inputArr,startIndex):
-  assert startIndex < len(inputArr)
-  assert startIndex >= 0
-  return inputArr[startIndex:] + inputArr[:startIndex]
-
-def offsetEnum(inputGen,offset):
-  for i,item in enumerate(inputGen):
-    yield (i+offset,item)
-
-def arrEndsWith(inputArr,testArr):
-  testStartIndex = len(inputArr)-len(testArr)
-  if testStartIndex < 0:
-    raise ValueError("This test can't be performed because testArr is longer than inputArr.")
-  return all((inputArr[testStartIndex+i]==testArr[i]) for i in range(len(testArr)))
+def rjustArr(inputArr, length, fillItem=0, crop=False):
+    if length < 0:
+        raise ValueError("length cannot be negative.")
+    return [fillItem for _ in range(length - len(inputArr))] + (
+        ([] if length == 0 else ([inputArr[-1]] if length == 1 else inputArr[-length:])) if crop else inputArr
+    )
 
 
+def unwrapArr(inputArr, startIndex):
+    assert startIndex < len(inputArr)
+    assert startIndex >= 0
+    return inputArr[startIndex:] + inputArr[:startIndex]
 
 
-fibNums = [0,1,1,2,3,5,8,13,21,34,55]
+def offsetEnum(inputGen, offset):
+    for i, item in enumerate(inputGen):
+        yield i + offset, item
+
+
+def arrEndsWith(inputArr, testArr):
+    testStartIndex = len(inputArr) - len(testArr)
+    if testStartIndex < 0:
+        raise ValueError("This test can't be performed because testArr is longer than inputArr.")
+    return all((inputArr[testStartIndex + i] == testArr[i]) for i in range(len(testArr)))
+
+
+fibNums = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
+
 
 def expandFibNums():
-  for i in range(256):
-    fibNums.append(fibNums[-1]+fibNums[-2])
+    for _ in range(256):
+        fibNums.append(fibNums[-1] + fibNums[-2])
+
 
 expandFibNums()
 
-tribNums = [0, 0, 1, 1, 2, 4, 7, 13, 24, 44, 81, 149, 274, 504, 927, 1705, 3136, 5768, 10609, 19513, 35890, 66012]
+tribNums = [
+    0,
+    0,
+    1,
+    1,
+    2,
+    4,
+    7,
+    13,
+    24,
+    44,
+    81,
+    149,
+    274,
+    504,
+    927,
+    1705,
+    3136,
+    5768,
+    10609,
+    19513,
+    35890,
+    66012,
+]
 
 """
 11 = 1
@@ -129,543 +157,543 @@ tribNums = [0, 0, 1, 1, 2, 4, 7, 13, 24, 44, 81, 149, 274, 504, 927, 1705, 3136,
   Can each digit place really be given a fixed value?
 """
 
-def getEnbonacciStartArr(order=2):
-  assert order > 1
-  return [0 for i in range(order-1)] + [1]
 
-assert getEnbonacciStartArr(order=2) == [0,1]
-assert getEnbonacciStartArr(order=3) == [0,0,1]
-  
+def getEnbonacciStartArr(order=2):
+    assert order > 1
+    return [0 for _ in range(order - 1)] + [1]
+
+
+assert getEnbonacciStartArr(order=2) == [0, 1]
+assert getEnbonacciStartArr(order=3) == [0, 0, 1]
+
 
 def genEnbonacciNums(order=2):
-  assert order > 1
-  startArr = getEnbonacciStartArr(order=order)
-  i = 0
-  while i < len(startArr):
-    yield startArr[i]
-    i += 1
-  workingArr = [item for item in startArr]
-  while True:
-    i %= order
-    workingArr[i] = sum(workingArr)
-    yield workingArr[i]
-    i += 1
-
-assert arrTakeOnly(genEnbonacciNums(order=2),8) == [0,1,1,2,3,5,8,13]
-assert arrTakeOnly(genEnbonacciNums(order=3),8) == [0,0,1,1,2,4,7,13]
+    assert order > 1
+    startArr = getEnbonacciStartArr(order=order)
+    i = 0
+    while i < len(startArr):
+        yield startArr[i]
+        i += 1
+    workingArr = [item for item in startArr]
+    while True:
+        i %= order
+        workingArr[i] = sum(workingArr)
+        yield workingArr[i]
+        i += 1
 
 
-def getEnboNumAtIndexAndPredecessors(n,order=2):
-  assert n > 0
-  assert order > 1
-  startArr = getEnbonacciStartArr(order=order)
-  if n < len(startArr):
-    result = rjustArr(startArr[:n+1],order,crop=True)
-    return result
-  workingArr = [item for item in startArr]
-  i = order-1
-  while i < n:
-    i += 1
-    ii = i%order
-    workingArr[ii] = sum(workingArr)
-  assert i == n
-  return makeArr(offsetEnum(unwrapArr(workingArr,i%order),i))
+assert arrTakeOnly(genEnbonacciNums(order=2), 8) == [0, 1, 1, 2, 3, 5, 8, 13]
+assert arrTakeOnly(genEnbonacciNums(order=3), 8) == [0, 0, 1, 1, 2, 4, 7, 13]
 
-def getEnboNumAboveValueAndPredecessors(value,order=2):
-  assert order > 1
-  startArr = getEnbonacciStartArr(order=order)
-  index = len(startArr) - 1
-  if value < startArr[index]:
-    assert index - (order-1) >= 0
-    while value < startArr[index-1]: #this might be designed too far above the value.
-      index -= 1
-    assert startArr[index-1] <= value
-    assert startArr[index] > value
-    #return ((index-1,fibNums[index-1]),(index,fibNums[index]))
-    result = makeArr(enumerate(startArr)[:index+1])
-    for i,item in enumerate(result):
-      assert item[i][0] == i
-    return result
-  workingArr = [item for item in startArr]
-  i = order-1
-  #ii = None
-  while True:
-    i += 1
-    ii = i%order
-    workingArr[ii] = sum(workingArr)
-    if not workingArr[ii] < value:
-      break
-  return makeArr(offsetEnum(unwrapArr(workingArr,(i+1)%order),i-(order-1)))
 
-def genEnboNumsDescendingFromIndex(iEnd,order=2):
-  assert order > 1
-  workingArr = getEnboNumAtIndexAndPredecessors(iEnd,order=order)
-  return genEnboNumsDescendingFromPreset(workingArr,iEnd,order=order)  
+def getEnboNumAtIndexAndPredecessors(n, order=2):
+    assert n > 0
+    assert order > 1
+    startArr = getEnbonacciStartArr(order=order)
+    if n < len(startArr):
+        return rjustArr(startArr[: n + 1], order, crop=True)
+    workingArr = [item for item in startArr]
+    i = order - 1
+    while i < n:
+        i += 1
+        ii = i % order
+        workingArr[ii] = sum(workingArr)
+    assert i == n
+    return makeArr(offsetEnum(unwrapArr(workingArr, i % order), i))
 
-def genEnboNumsDescendingFromPreset(presetArr,iEnd=None,order=2):
-  assert order > 1
-  #print("genEnboNumsDescendingFromPreset: on call: (presetArr,iEnd,order)=" + str((presetArr,iEnd,order)) + ".")
-  isEnumerated = all(type(item) == tuple for item in presetArr)
-  if isEnumerated and (iEnd != None):
-    assert presetArr[-1][0] == iEnd
-  else:
-    iEnd = presetArr[-1][0]
-  #print("genEnboNumsDescendingFromPreset: after adjustment: (presetArr,iEnd,order)=" + str((presetArr,iEnd,order)) + ".")
-  workingArr = None
-  if isEnumerated:
-    workingArr = [item[1] for item in presetArr]
-  else:
-    workingArr = [item for item in presetArr] #make copy.
-  yield (iEnd, workingArr[-1])
-  #print("(workingArr,iEnd,order)="+str((workingArr,iEnd,order))+".")
-  while iEnd >= order:
-    workingArr.insert(0,workingArr[-1]-sum(workingArr[:-1]))
-    del workingArr[-1]
-    iEnd -= 1
-    #print("genEnboNumsDescendingFromPreset: yielding " + str((iEnd, workingArr[-1])) + ".")
-    yield (iEnd, workingArr[-1])
-    #print("in loop, (workingArr,iEnd,order)="+str((workingArr,iEnd,order))+".")
-  assert workingArr[0] == 0
-  assert iEnd == order - 1
-  #for i,item in makeArr(enumerate(getEnbonacciStartArr(order=order)))[::-1]:
-  #  yield (i,item)
-  for i,item in makeArr(enumerate(workingArr))[::-1]:
-    if i == iEnd or i == iEnd-1:
-      continue
-    #print("genEnboNumsDescendingFromPreset: yielding " + str((i, item)) + ".")
-    yield (i,item)
 
-def genEnboNumsDescendingFromValue(value,order=2):
-  presetArr = getEnboNumAboveValueAndPredecessors(value,order=order)
-  #print("getEnboNumsDescendingFromValue: (value,order,presetArr)=" + str((value,order,presetArr))+".")
-  return genEnboNumsDescendingFromPreset(presetArr,iEnd=None,order=order)
+def getEnboNumAboveValueAndPredecessors(value, order=2):
+    assert order > 1
+    startArr = getEnbonacciStartArr(order=order)
+    index = len(startArr) - 1
+    if value < startArr[index]:
+        assert index - (order - 1) >= 0
+        while value < startArr[index - 1]:  # this might be designed too far above the value.
+            index -= 1
+        assert startArr[index - 1] <= value
+        assert startArr[index] > value
+        # return ((index-1,fibNums[index-1]),(index,fibNums[index]))
+        result = makeArr(enumerate(startArr)[: index + 1])
+        for i, item in enumerate(result):
+            assert item[i][0] == i
+        return result
+    workingArr = [item for item in startArr]
+    i = order - 1
+    # ii = None
+    while True:
+        i += 1
+        ii = i % order
+        workingArr[ii] = sum(workingArr)
+        if workingArr[ii] >= value:
+            break
+    return makeArr(offsetEnum(unwrapArr(workingArr, (i + 1) % order), i - (order - 1)))
+
+
+def genEnboNumsDescendingFromIndex(iEnd, order=2):
+    assert order > 1
+    workingArr = getEnboNumAtIndexAndPredecessors(iEnd, order=order)
+    return genEnboNumsDescendingFromPreset(workingArr, iEnd, order=order)
+
+
+def genEnboNumsDescendingFromPreset(presetArr, iEnd=None, order=2):
+    assert order > 1
+    # print("genEnboNumsDescendingFromPreset: on call: (presetArr,iEnd,order)=" + str((presetArr,iEnd,order)) + ".")
+    isEnumerated = all(type(item) == tuple for item in presetArr)
+    if isEnumerated and (iEnd is not None):
+        assert presetArr[-1][0] == iEnd
+    else:
+        iEnd = presetArr[-1][0]
+    # print("genEnboNumsDescendingFromPreset: after adjustment: (presetArr,iEnd,order)=" +
+    # str((presetArr,iEnd,order)) + ".")
+    if isEnumerated:
+        workingArr = [item[1] for item in presetArr]
+    else:
+        workingArr = [item for item in presetArr]  # make copy.
+    yield iEnd, workingArr[-1]
+    # print("(workingArr,iEnd,order)="+str((workingArr,iEnd,order))+".")
+    while iEnd >= order:
+        workingArr.insert(0, workingArr[-1] - sum(workingArr[:-1]))
+        del workingArr[-1]
+        iEnd -= 1
+        # print("genEnboNumsDescendingFromPreset: yielding " + str((iEnd, workingArr[-1])) + ".")
+        yield iEnd, workingArr[-1]
+        # print("in loop, (workingArr,iEnd,order)="+str((workingArr,iEnd,order))+".")
+    assert workingArr[0] == 0
+    assert iEnd == order - 1
+    # for i,item in makeArr(enumerate(getEnbonacciStartArr(order=order)))[::-1]:
+    #  yield (i,item)
+    for i, item in makeArr(enumerate(workingArr))[::-1]:
+        if i in [iEnd, iEnd - 1]:
+            continue
+        # print("genEnboNumsDescendingFromPreset: yielding " + str((i, item)) + ".")
+        yield i, item
+
+
+def genEnboNumsDescendingFromValue(value, order=2):
+    presetArr = getEnboNumAboveValueAndPredecessors(value, order=order)
+    # print("getEnboNumsDescendingFromValue: (value,order,presetArr)=" + str((value,order,presetArr))+".")
+    return genEnboNumsDescendingFromPreset(presetArr, iEnd=None, order=order)
 
 
 def isInt(x):
-  return type(x) in [int,long]
-try:
-  assert isInt(2**128)
-except NameError:
-  print("Codes: long type does not exist in this version of python, so isInt(x) will not check for it.")
-  def isInt(x):
     return type(x) == int
 
 
+try:
+    assert isInt(2 ** 128)
+except NameError:
+    print("Codes: long type does not exist in this version of python, so isInt(x) will not check for it.")
+
+    def isInt(x):
+        return type(x) == int
+
+
 class ParseError(Exception):
-  pass
-
-
+    pass
 
 
 def intToBinaryBitArr(inputInt):
-  return [int(char) for char in bin(inputInt)[2:]]
+    return [int(char) for char in bin(inputInt)[2:]]
+
 
 def binaryBitArrToInt(inputBitArr):
-  return sum(2**i*inputBitArr[-1-i] for i in range(len(inputBitArr)))
+    return sum(2 ** i * inputBitArr[-1 - i] for i in range(len(inputBitArr)))
 
 
-def extendIntByBits(headInt,inputBitSeq,bitCount,onExhaustion="fail"):
-  #this function eats up to bitCount bits from an inputBitSeq and returns an integer based on the input headInt followed by those generated bits.
-  assert onExhaustion in ["fail","warn+partial","warn+None","partial","None"]
-  assert type(headInt) == int
-  assert type(bitCount) == int
-  if bitCount == 0:
-    return headInt
-  result = headInt
-  i = 0
-  for inputBit in inputBitSeq:
-    #print("new inputBit is " +str(inputBit) + ".")
-    result = result*2 + inputBit
-    #print("result is " + str(result))
-    i += 1
-    if i >= bitCount:
-      return result
-  if onExhaustion == "fail":
-    raise ExhaustionError("Codes.extendIntByBits ran out of bits, and its onExhaustion action is \"fail\".")
-  if "warn" in onExhaustion:
-    print("Codes.extendIntByBits ran out of bits, and may return an undesired value.")
-  if "partial" in onExhaustion:
-    return result
-  elif "None" in onExhaustion:
-    return None
-  else:
-    raise ValueError("Codes.extendIntByBits: the value of keyword argument onExhaustion is invalid.")
+def extendIntByBits(headInt, inputBitSeq, bitCount, onExhaustion="fail"):
+    # this function eats up to bitCount bits from an inputBitSeq and returns an integer based on the input headInt
+    # followed by those generated bits.
+    assert onExhaustion in ["fail", "warn+partial", "warn+None", "partial", "None"]
+    assert type(headInt) == int
+    assert type(bitCount) == int
+    if bitCount == 0:
+        return headInt
+    result = headInt
+    for i, inputBit in enumerate(inputBitSeq, start=1):
+        # print("new inputBit is " +str(inputBit) + ".")
+        result = result * 2 + inputBit
+        if i >= bitCount:
+            return result
+    if onExhaustion == "fail":
+        raise ExhaustionError('Codes.extendIntByBits ran out of bits, and its onExhaustion action is "fail".')
+    if "warn" in onExhaustion:
+        print("Codes.extendIntByBits ran out of bits, and may return an undesired value.")
+    if "partial" in onExhaustion:
+        return result
+    elif "None" in onExhaustion:
+        return None
+    else:
+        raise ValueError("Codes.extendIntByBits: the value of keyword argument onExhaustion is invalid.")
 
-def intSeqToBitSeq(inputIntSeq,inputFun,addDbgChars=False):
-  justStarted = True
-  for inputInt in inputIntSeq:
+
+def intSeqToBitSeq(inputIntSeq, inputFun, addDbgChars=False):
+    justStarted = True
+    for inputInt in inputIntSeq:
+        if addDbgChars:
+            if justStarted:
+                justStarted = False
+            else:
+                yield ","
+        yield from inputFun(inputInt)
+
+
+def bitSeqToIntSeq(inputBitSeq, inputFun):
+    inputBitSeq = makeGen(inputBitSeq)
+    while True:
+        try:
+            outputInt = inputFun(inputBitSeq)
+        except ExhaustionError:
+            # print("bitSeqToIntSeq is stopping.")
+            return
+        if outputInt is None:
+            raise ParseError("The inputFun " + str(inputFun) + " did not properly terminate.")
+        yield outputInt
+
+
+def intToHybridCodeBitSeq(inputInt, prefixEncoderFun, zeroSafe, addDbgChars=False):
+    # the resulting hybrid code is never zero safe, and the zeroSafe arg only refers to whether the prefix function is.
+    bodyBitArr = intToBinaryBitArr(inputInt)[1:]
+    prefixBitSeq = prefixEncoderFun(len(bodyBitArr) + (0 if zeroSafe else 1))
+    yield from prefixBitSeq
     if addDbgChars:
-      if justStarted:
-        justStarted = False
-      else:
-        yield ","
-    for outputBit in inputFun(inputInt):
-      yield outputBit
+        yield "."
+    yield from bodyBitArr
 
-def bitSeqToIntSeq(inputBitSeq,inputFun):
-  inputBitSeq = makeGen(inputBitSeq)
-  outputInt = None
-  while True:
+
+def hybridCodeBitSeqToInt(inputBitSeq, prefixDecoderFun, zeroSafe):
+    # the resulting hybrid code is never zero safe, and the zeroSafe arg only refers to whether the prefix function is.
+    inputBitSeq = makeGen(inputBitSeq)
+    prefixParseResult = prefixDecoderFun(inputBitSeq) - (0 if zeroSafe else 1)
     try:
-      outputInt = inputFun(inputBitSeq)
+        decodedValue = extendIntByBits(1, inputBitSeq, prefixParseResult)
     except ExhaustionError:
-      #print("bitSeqToIntSeq is stopping.")
-      return
-    if outputInt == None:
-      raise ParseError("The inputFun " + str(inputFun) + " did not properly terminate.")
-    yield outputInt
+        raise ParseError("Codes.hybridCodeBitSeqToInt ran out of bits before receiving as many as its prefix promised.")
+    return decodedValue
 
 
-def intToHybridCodeBitSeq(inputInt,prefixEncoderFun,zeroSafe,addDbgChars=False):
-  #the resulting hybrid code is never zero safe, and the zeroSafe arg only refers to whether the prefix function is.
-  bodyBitArr = intToBinaryBitArr(inputInt)[1:]
-  prefixBitSeq = prefixEncoderFun(len(bodyBitArr) + (0 if zeroSafe else 1))
-  for outputBit in prefixBitSeq:
-    yield outputBit
-  if addDbgChars:
-    yield "."
-  for outputBit in bodyBitArr:
-    yield outputBit
+def intToEnbocodeBitArr(inputInt, order=2):
+    # This function hasn't been replaced with or converted to a generator because doing so has no benefits - the
+    # bits must be generated in backwards order anyway, so it makes no sense to convert to a generator and then
+    # convert back.
+    assert order == 2  # because the current design of this method is completely unable to handle other orders.
+    assert isInt(inputInt)
+    assert inputInt >= 1
+    result = []
+    currentInt = inputInt
+    for index, enboNum in genEnboNumsDescendingFromValue(inputInt * 2 + 10, order=order):
 
-def hybridCodeBitSeqToInt(inputBitSeq,prefixDecoderFun,zeroSafe):
-  #the resulting hybrid code is never zero safe, and the zeroSafe arg only refers to whether the prefix function is.
-  inputBitSeq = makeGen(inputBitSeq)
-  prefixParseResult = prefixDecoderFun(inputBitSeq) - (0 if zeroSafe else 1)
-  decodedValue = None
-  try:
-    decodedValue = extendIntByBits(1,inputBitSeq,prefixParseResult)
-  except ExhaustionError:
-    raise ParseError("Codes.hybridCodeBitSeqToInt ran out of bits before receiving as many as its prefix promised.")
-  return decodedValue
+        # print("intToEnbocodeBitArr: before loop body: (inputInt,order,index,enboNum,result)=" +
+        # str((inputInt,order,index,enboNum,result)) + ".")
+        if index < order:
+            # print("intToEnbocodeBitArr: breaking loop because of index.")
+            break
+        assert enboNum > 0
+        if enboNum <= currentInt:
+            # print("intToEnbocodeBitArr: enboNum will be subtracted from currentInt. (currentInt,index,enboNum)"+
+            # str((currentInt,index,enboNum))+".")
+            currentInt -= enboNum
+            result.append(1)
+            # print("intToEnbocodeBitArr: enboNum has been subtracted from currentInt.
+            # (currentInt,index,enboNum,result)"+str((currentInt,index,enboNum,result))+".")
+        elif result:
+            result.append(0)
+            # print("intToEnbocodeBitArr: nothing has been subtracted from currentInt this time around.
+            # (currentInt,index,enboNum,result)"+str((currentInt,index,enboNum,result))+".")
+            # print("intToEnbocodeBitArr: after loop body: (inputInt,order,index,enboNum,result)=" +
+            # str((inputInt,order,index,enboNum,result)) + ".")
 
+    result.reverse()
+    assert len(result) > 0
+    result.extend([1 for _ in range(order - 1)])
+    assert len(result) >= order
+    # return result[1:] #I don't know why this is necessary.
 
+    # print("fix intToEnbocodeBitArr")
+    if order == 2:
+        if inputInt <= 4 and result != [None, [1, 1], [0, 1, 1], [0, 0, 1, 1], [1, 0, 1, 1]][inputInt]:
+            raise ValueError("intToEnbocodeBitArr: {}->{}".format(inputInt, result) + ".")
+    elif order == 3:
+        if inputInt <= 4 and result != [
+            None,
+            [1, 1, 1],
+            [0, 1, 1, 1],
+            [0, 0, 1, 1, 1],
+            [1, 0, 1, 1, 1],
+        ][inputInt]:
+            raise ValueError("intToEnbocodeBitArr: order={}, {}->{}".format(order, inputInt, result) + ".")
 
+    # print("intToEnbocodeBitArr: before final tests: (inputInt,order,result)=" + str((inputInt,order,result)) + ".")
 
-
-
-
-
-
-def intToEnbocodeBitArr(inputInt,order=2):
-  #This function hasn't been replaced with or converted to a generator because doing so has no benefits - the bits must be generated in backwards order anyway, so it makes no sense to convert to a generator and then convert back.
-  assert order == 2 #because the current design of this method is completely unable to handle other orders.
-  assert isInt(inputInt)
-  assert inputInt >= 1
-  result = []
-  currentInt = inputInt
-  for index,enboNum in genEnboNumsDescendingFromValue(inputInt*2+10,order=order):
-
-    #print("intToEnbocodeBitArr: before loop body: (inputInt,order,index,enboNum,result)=" + str((inputInt,order,index,enboNum,result)) + ".")
-    if index < order:
-      #print("intToEnbocodeBitArr: breaking loop because of index.")
-      break
-    assert enboNum > 0
-    if enboNum <= currentInt:
-      #print("intToEnbocodeBitArr: enboNum will be subtracted from currentInt. (currentInt,index,enboNum)"+str((currentInt,index,enboNum))+".")
-      currentInt -= enboNum
-      result.append(1)
-      #print("intToEnbocodeBitArr: enboNum has been subtracted from currentInt. (currentInt,index,enboNum,result)"+str((currentInt,index,enboNum,result))+".")
-    else:
-      if len(result) > 0:
-        result.append(0)
-        #print("intToEnbocodeBitArr: nothing has been subtracted from currentInt this time around. (currentInt,index,enboNum,result)"+str((currentInt,index,enboNum,result))+".")
-    if currentInt == 0:
-      #print("intToEnbocodeBitArr: it is possible to break the loop because of currentInt. The loop won't be broken.")
-      pass
-    #print("intToEnbocodeBitArr: after loop body: (inputInt,order,index,enboNum,result)=" + str((inputInt,order,index,enboNum,result)) + ".")
-
-  result.reverse()
-  assert len(result) > 0
-  result.extend([1 for i in range(order-1)])
-  assert len(result) >= order
-  #return result[1:] #I don't know why this is necessary.
-  
-  #print("fix intToEnbocodeBitArr")
-  if order == 2:
-    if inputInt <= 4:
-      if not result == [None,[1,1],[0,1,1],[0,0,1,1],[1,0,1,1]][inputInt]:
-        raise ValueError("intToEnbocodeBitArr: {}->{}".format(inputInt,result)+".")
-  elif order == 3:
-    if inputInt <= 4:
-      if not result == [None,[1,1,1],[0,1,1,1],[0,0,1,1,1],[1,0,1,1,1]][inputInt]:
-        raise ValueError("intToEnbocodeBitArr: order={}, {}->{}".format(order, inputInt,result)+".")
-
-  
-  #print("intToEnbocodeBitArr: before final tests: (inputInt,order,result)=" + str((inputInt,order,result)) + ".")
-
-  if len(result) > order:
-    if not arrEndsWith(result,[0]+[1 for i in range(order)]):
-      print("intToEnbocodeBitArr: result ends the wrong way. This is never supposed to happen. (inputInt,order,result)=" + str((inputInt,order,result)) + ".")
-  return result
+    if len(result) > order and not arrEndsWith(result, [0] + [1 for _ in range(order)]):
+        print(
+            "intToEnbocodeBitArr: result ends the wrong way. This is never supposed to happen. (inputInt,order,result)="
+            + str((inputInt, order, result))
+            + "."
+        )
+    return result
 
 
-def intToEnbocodeBitSeq(inputInt,order=2):
-  #exists only for uniform naming of functions.
-  assert order == 2 #to reflect the fact that the current design of this method is completely unable to handle other orders.
-  for outputBit in intToEnbocodeBitArr(inputInt,order=order):
-    yield outputBit
+def intToEnbocodeBitSeq(inputInt, order=2):
+    # exists only for uniform naming of functions.
+    assert (
+        order == 2
+    )  # to reflect the fact that the current design of this method is completely unable to handle other orders.
+    yield from intToEnbocodeBitArr(inputInt, order=order)
 
 
-def enbocodeBitSeqToInt(inputBitSeq,order=2):
-  #this function only eats as much of the provided generator as it needs.
-  #it used to be more memory efficient by not keeping a bitHistory, but that design made upgrading to any-order fibonacci harder, so it was written out. It could be brought back now.
-  assert order == 2 #to reflect the fact that the current design of this method is completely unable to handle other orders.
-  
-  assert order > 1
-  inputBitSeq = makeGen(inputBitSeq)
-  bitHistory = [] 
-  for i,inputBit in enumerate(inputBitSeq):
-    assert inputBit in [0,1]
-    bitHistory.append(inputBit)
-    if sum(bitHistory[-order:]) == order:
-      break
-  
-  #print("enbocodeBitSeqToInt: (order,bitHistory)="+str((order,bitHistory))+".")
+def enbocodeBitSeqToInt(inputBitSeq, order=2):
+    # this function only eats as much of the provided generator as it needs.
+    # it used to be more memory efficient by not keeping a bitHistory, but that design made upgrading to any-order
+    # fibonacci harder, so it was written out. It could be brought back now.
+    assert (
+        order == 2
+    )  # to reflect the fact that the current design of this method is completely unable to handle other orders.
 
-  if len(bitHistory) == 0:
-    raise ExhaustionError("enbocodeBitSeqToInt received an empty inputBitSeq.")
-  if len(bitHistory) > 0 and len(bitHistory) < order:
-    raise ParseError("The inputBitSeq did not end in an enbonacci code.")
-  
-  #temp:
-  if len(bitHistory) >= order:
-    assert arrEndsWith(bitHistory,[1 for i in range(order)])
-  if len(bitHistory) >= order+1:
-    assert arrEndsWith(bitHistory,[0]+[1 for i in range(order)])
+    assert order > 1
+    inputBitSeq = makeGen(inputBitSeq)
+    bitHistory = []
+    for i, inputBit in enumerate(inputBitSeq):
+        assert inputBit in [0, 1]
+        bitHistory.append(inputBit)
+        if sum(bitHistory[-order:]) == order:
+            break
 
-  enboNumGen = genSkipFirst(genEnbonacciNums(order),order) #@ cleanup.
-  result = 0
-  for i,currentEnboNum in enumerate(enboNumGen): #this might generate one more enboNum than is needed.
-    assert currentEnboNum > 0
-    if i == len(bitHistory) - (order-1): #if this was the last bit that wasn't part of the stopcode...
-      break
-    result += currentEnboNum * bitHistory[i]
+    # print("enbocodeBitSeqToInt: (order,bitHistory)="+str((order,bitHistory))+".")
 
-  #temp:
-  #print("fix enbocodeBitSeqToInt.")
-  if all(bitHistory):
-    assert len(bitHistory) == order
-    assert result == 1
-  elif bitHistory == [0] + [1 for i in range(order)]:
-    assert result == 2
-  elif bitHistory == [0,0] + [1 for i in range(order)]:
-    assert result == 3
-  assert result > 0
-  return result
-  """
-  if result != 0:
-    raise ParseError("Codes.enbocodeBitSeqToInt ran out of input bits midword.")
-  else:
-    if loopRan:
-      assert False, "Codes.enbocodeBitSeqToInt crashed."
-    else:
-      raise ExhaustionError("Codes.enbocodeBitSeqToInt received an empty generator.")
-  """
+    if not bitHistory:
+        raise ExhaustionError("enbocodeBitSeqToInt received an empty inputBitSeq.")
+    if len(bitHistory) < order:
+        raise ParseError("The inputBitSeq did not end in an enbonacci code.")
+
+    # temp:
+    if len(bitHistory) >= order:
+        assert arrEndsWith(bitHistory, [1 for i in range(order)])
+    if len(bitHistory) >= order + 1:
+        assert arrEndsWith(bitHistory, [0] + [1 for i in range(order)])
+
+    enboNumGen = genSkipFirst(genEnbonacciNums(order), order)  # @ cleanup.
+    result = 0
+    for i, currentEnboNum in enumerate(enboNumGen):  # this might generate one more enboNum than is needed.
+        assert currentEnboNum > 0
+        if i == len(bitHistory) - (order - 1):  # if this was the last bit that wasn't part of the stopcode...
+            break
+        result += currentEnboNum * bitHistory[i]
+
+    # temp:
+    # print("fix enbocodeBitSeqToInt.")
+    if all(bitHistory):
+        assert len(bitHistory) == order
+        assert result == 1
+    elif bitHistory == [0] + [1 for i in range(order)]:
+        assert result == 2
+    elif bitHistory == [0, 0] + [1 for i in range(order)]:
+        assert result == 3
+    assert result > 0
+    return result
 
 
-def intSeqToEnbocodeBitSeq(inputIntSeq,order=2):
-  return intSeqToBitSeq(inputIntSeq,(lambda x: intToEnbocodeBitSeq(x,order=order)))
-
-def enbocodeBitSeqToIntSeq(inputBitSeq,order=2):
-  return bitSeqToIntSeq(inputBitSeq,(lambda x: enbocodeBitSeqToInt(x,order=order)))
+def intSeqToEnbocodeBitSeq(inputIntSeq, order=2):
+    return intSeqToBitSeq(inputIntSeq, (lambda x: intToEnbocodeBitSeq(x, order=order)))
 
 
-#temp
+def enbocodeBitSeqToIntSeq(inputBitSeq, order=2):
+    return bitSeqToIntSeq(inputBitSeq, (lambda x: enbocodeBitSeqToInt(x, order=order)))
+
+
+# temp
 def intToFibcodeBitSeq(inputInt):
-  return intToEnbocodeBitSeq(inputInt,order=2)
+    return intToEnbocodeBitSeq(inputInt, order=2)
+
+
 def fibcodeBitSeqToInt(inputBitSeq):
-  return enbocodeBitSeqToInt(inputBitSeq,order=2)
+    return enbocodeBitSeqToInt(inputBitSeq, order=2)
 
 
 def intToUnaryBitSeq(inputInt):
-  for i in range(inputInt):
-    yield 0
-  yield 1
+    for _ in range(inputInt):
+        yield 0
+    yield 1
+
 
 def unaryBitSeqToInt(inputBitSeq):
-  inputBitSeq = makeGen(inputBitSeq)
-  result = 0
-  for inputBit in inputBitSeq:
-    if inputBit == 0:
-      result += 1
-    else:
-      return result
-  if result != 0:
-    raise ParseError("Codes.unaryBitSeqToInt ran out of input bits midword.")
-  raise ExhaustionError("Codes.unaryBitSeqToInt ran out of bits.")
-
-
-
-
-
-
+    inputBitSeq = makeGen(inputBitSeq)
+    result = 0
+    for inputBit in inputBitSeq:
+        if inputBit == 0:
+            result += 1
+        else:
+            return result
+    if result != 0:
+        raise ParseError("Codes.unaryBitSeqToInt ran out of input bits midword.")
+    raise ExhaustionError("Codes.unaryBitSeqToInt ran out of bits.")
 
 
 def intToEliasGammaBitSeq(inputInt):
-  assert inputInt >= 1
-  for outputBit in intToUnaryBitSeq(inputInt.bit_length()-1):
-    yield outputBit
-  for outputBit in (int(char) for char in bin(inputInt)[3:]):
-    yield outputBit
+    assert inputInt >= 1
+    yield from intToUnaryBitSeq(inputInt.bit_length() - 1)
+    yield from (int(char) for char in bin(inputInt)[3:])
+
 
 def eliasGammaBitSeqToInt(inputBitSeq):
-  inputBitSeq = makeGen(inputBitSeq)
-  prefixValue = unaryBitSeqToInt(inputBitSeq)
-  assert prefixValue != None, "None-based termination is being phased out."
-  #print("Codes.eliasGammaBitSeqToInt: prefixValue is " + str(prefixValue) + ".")
-  try:
-    return extendIntByBits(1,inputBitSeq,prefixValue)
-  except ExhaustionError:
-    raise ParseError("Codes.eliasGammaBitSeqToInt ran out of input bits before receiving as many as its unary prefix promised.")
-  #print("Codes.eliasGammaBitSeqToInt: result is " + str(result) + ".")
+    inputBitSeq = makeGen(inputBitSeq)
+    prefixValue = unaryBitSeqToInt(inputBitSeq)
+    assert prefixValue is not None, "None-based termination is being phased out."
+    # print("Codes.eliasGammaBitSeqToInt: prefixValue is " + str(prefixValue) + ".")
+    try:
+        return extendIntByBits(1, inputBitSeq, prefixValue)
+    except ExhaustionError:
+        raise ParseError(
+            "Codes.eliasGammaBitSeqToInt ran out of input bits before receiving as many as its unary prefix promised."
+        )
+    # print("Codes.eliasGammaBitSeqToInt: result is " + str(result) + ".")
 
 
 def intSeqToEliasGammaBitSeq(inputIntSeq):
-  return intSeqToBitSeq(inputIntSeq,intToEliasGammaBitSeq)
+    return intSeqToBitSeq(inputIntSeq, intToEliasGammaBitSeq)
+
 
 def eliasGammaBitSeqToIntSeq(inputBitSeq):
-  return bitSeqToIntSeq(inputBitSeq,eliasGammaBitSeqToInt)
-
-
+    return bitSeqToIntSeq(inputBitSeq, eliasGammaBitSeqToInt)
 
 
 def intToEliasDeltaBitSeq(inputInt):
-  assert inputInt >= 1
-  payloadBits = intToBinaryBitArr(inputInt)[1:]
-  for outputBit in intToEliasGammaBitSeq(len(payloadBits)+1):
-    yield outputBit
-  for outputBit in payloadBits:
-    yield outputBit
+    assert inputInt >= 1
+    payloadBits = intToBinaryBitArr(inputInt)[1:]
+    yield from intToEliasGammaBitSeq(len(payloadBits) + 1)
+    yield from payloadBits
+
 
 def eliasDeltaBitSeqToInt(inputBitSeq):
-  inputBitSeq = makeGen(inputBitSeq)
-  prefixValue = eliasGammaBitSeqToInt(inputBitSeq)
-  assert prefixValue != None, "None-based termination is being phased out."
-  payloadBitCount = prefixValue - 1
-  #print("payloadBitCount is " + str(payloadBitCount))
-  try:
-    return extendIntByBits(1,inputBitSeq,payloadBitCount)
-  except ExhaustionError:
-    raise ParseError("Codes.eliasDeltaBitSeqToInt ran out of input bits before receiving as many as its Elias Gamma prefix promised.")
+    inputBitSeq = makeGen(inputBitSeq)
+    prefixValue = eliasGammaBitSeqToInt(inputBitSeq)
+    assert prefixValue is not None, "None-based termination is being phased out."
+    payloadBitCount = prefixValue - 1
+    # print("payloadBitCount is " + str(payloadBitCount))
+    try:
+        return extendIntByBits(1, inputBitSeq, payloadBitCount)
+    except ExhaustionError:
+        raise ParseError(
+            "Codes.eliasDeltaBitSeqToInt ran out of input bits before receiving as many as its Elias Gamma prefix"
+            " promised."
+        )
 
 
 def intSeqToEliasDeltaBitSeq(inputIntSeq):
-  return intSeqToBitSeq(inputIntSeq,intToEliasDeltaBitSeq)
+    return intSeqToBitSeq(inputIntSeq, intToEliasDeltaBitSeq)
+
 
 def eliasDeltaBitSeqToIntSeq(inputBitSeq):
-  return bitSeqToIntSeq(inputBitSeq,eliasDeltaBitSeqToInt)
+    return bitSeqToIntSeq(inputBitSeq, eliasDeltaBitSeqToInt)
 
 
-
-#eliasGamaIota and eliasDeltaIota are two codings I created to store integers with a limited range by setting the prefix involved in regular elias codes to a fixed length.
-#they are not perfect. When the maxInputInt looks like 10000010 and the prefix indicates that the body is 7 bits long, 7 bits are used to define the body when 2 would suffice.
-
-def intToEliasGammaIotaBitSeq(inputInt,maxInputInt):
-  assert inputInt > 0
-  assert inputInt <= maxInputInt
-  maxPayloadLength = len(bin(maxInputInt)[3:])
-  prefixLength = len(bin(maxPayloadLength)[2:])
-  payloadLength = len(bin(inputInt)[3:])
-  assert payloadLength <= maxPayloadLength
-  #print("maxPayloadLength="+str(maxPayloadLength))
-  #print("prefixLength="+str(prefixLength))
-  prefix = rjustArr(intToBinaryBitArr(payloadLength),prefixLength)
-  assert len(prefix) == prefixLength
-  result = prefix + intToBinaryBitArr(inputInt)[1:]
-  for outputBit in result:
-    yield outputBit
-
-def eliasGammaIotaBitSeqToInt(inputBitSeq,maxInputInt):
-  inputBitSeq = makeGen(inputBitSeq)
-  maxPayloadLength = len(bin(maxInputInt)[3:])
-  prefixLength = len(bin(maxPayloadLength)[2:])
-  prefixValue = binaryBitArrToInt(arrTakeOnly(inputBitSeq,prefixLength,onExhaustion="fail"))
-  assert prefixValue != None, "None-based termination is being phased out."
-  try:
-    return extendIntByBits(1,inputBitSeq,prefixValue)
-  except ExhaustionError:
-    raise ParseError("Codes.eliasGammaIotaBitSeqToInt ran out of input bits before receiving as many as its prefix promised.")
-  
-
-def intSeqToEliasGammaIotaBitSeq(inputIntSeq,maxInputInt):
-  return intSeqToBitSeq(inputIntSeq,(lambda x: intToEliasGammaIotaBitSeq(x,maxInputInt)))
-
-def eliasGammaIotaBitSeqToIntSeq(inputBitSeq,maxInputInt):
-  return bitSeqToIntSeq(inputBitSeq,(lambda x: eliasGammaIotaBitSeqToInt(x,maxInputInt)))
+# eliasGamaIota and eliasDeltaIota are two codings I created to store integers with a limited range by setting the
+# prefix involved in regular elias codes to a fixed length.
+# they are not perfect. When the maxInputInt looks like 10000010 and the prefix indicates that the body is 7 bits
+# long, 7 bits are used to define the body when 2 would suffice.
 
 
-
-def intToEliasDeltaIotaBitSeq(inputInt,maxInputInt):
-  assert inputInt > 0
-  assert inputInt <= maxInputInt
-  maxBodyLength = len(bin(maxInputInt)[3:])
-  result = intToHybridCodeBitSeq(inputInt,(lambda x: intToEliasGammaIotaBitSeq(x,maxBodyLength+1)),False)
-  assert result != None
-  return result
-
-def eliasDeltaIotaBitSeqToInt(inputBitSeq,maxInputInt):
-  assert maxInputInt > 0
-  maxBodyLength = len(bin(maxInputInt)[3:])
-  result = hybridCodeBitSeqToInt(inputBitSeq,(lambda x: eliasGammaIotaBitSeqToInt(x,maxBodyLength+1)),False)
-  assert result != None
-  return result
+def intToEliasGammaIotaBitSeq(inputInt, maxInputInt):
+    assert inputInt > 0
+    assert inputInt <= maxInputInt
+    maxPayloadLength = len(bin(maxInputInt)[3:])
+    prefixLength = len(bin(maxPayloadLength)[2:])
+    payloadLength = len(bin(inputInt)[3:])
+    assert payloadLength <= maxPayloadLength
+    # print("maxPayloadLength="+str(maxPayloadLength))
+    # print("prefixLength="+str(prefixLength))
+    prefix = rjustArr(intToBinaryBitArr(payloadLength), prefixLength)
+    assert len(prefix) == prefixLength
+    result = prefix + intToBinaryBitArr(inputInt)[1:]
+    yield from result
 
 
-def intSeqToEliasDeltaIotaBitSeq(inputIntSeq,maxInputInt):
-  return intSeqToBitSeq(inputIntSeq,(lambda x: intToEliasDeltaIotaBitSeq(x,maxInputInt)))
+def eliasGammaIotaBitSeqToInt(inputBitSeq, maxInputInt):
+    inputBitSeq = makeGen(inputBitSeq)
+    maxPayloadLength = len(bin(maxInputInt)[3:])
+    prefixLength = len(bin(maxPayloadLength)[2:])
+    prefixValue = binaryBitArrToInt(arrTakeOnly(inputBitSeq, prefixLength, onExhaustion="fail"))
+    assert prefixValue is not None, "None-based termination is being phased out."
+    try:
+        return extendIntByBits(1, inputBitSeq, prefixValue)
+    except ExhaustionError:
+        raise ParseError(
+            "Codes.eliasGammaIotaBitSeqToInt ran out of input bits before receiving as many as its prefix promised."
+        )
 
-def eliasDeltaIotaBitSeqToIntSeq(inputBitSeq,maxInputInt):
-  return bitSeqToIntSeq(inputBitSeq,(lambda x: eliasDeltaIotaBitSeqToInt(x,maxInputInt)))
+
+def intSeqToEliasGammaIotaBitSeq(inputIntSeq, maxInputInt):
+    return intSeqToBitSeq(inputIntSeq, (lambda x: intToEliasGammaIotaBitSeq(x, maxInputInt)))
 
 
+def eliasGammaIotaBitSeqToIntSeq(inputBitSeq, maxInputInt):
+    return bitSeqToIntSeq(inputBitSeq, (lambda x: eliasGammaIotaBitSeqToInt(x, maxInputInt)))
 
 
-def intToEliasGammaFibBitSeq(inputInt,addDbgChars=False):
-  assert inputInt > 0
-  result = intToHybridCodeBitSeq(inputInt,intToFibcodeBitSeq,False,addDbgChars=addDbgChars)
-  assert result != None
-  return result
+def intToEliasDeltaIotaBitSeq(inputInt, maxInputInt):
+    assert inputInt > 0
+    assert inputInt <= maxInputInt
+    maxBodyLength = len(bin(maxInputInt)[3:])
+    result = intToHybridCodeBitSeq(inputInt, (lambda x: intToEliasGammaIotaBitSeq(x, maxBodyLength + 1)), False)
+    assert result is not None
+    return result
+
+
+def eliasDeltaIotaBitSeqToInt(inputBitSeq, maxInputInt):
+    assert maxInputInt > 0
+    maxBodyLength = len(bin(maxInputInt)[3:])
+    result = hybridCodeBitSeqToInt(inputBitSeq, (lambda x: eliasGammaIotaBitSeqToInt(x, maxBodyLength + 1)), False)
+    assert result is not None
+    return result
+
+
+def intSeqToEliasDeltaIotaBitSeq(inputIntSeq, maxInputInt):
+    return intSeqToBitSeq(inputIntSeq, (lambda x: intToEliasDeltaIotaBitSeq(x, maxInputInt)))
+
+
+def eliasDeltaIotaBitSeqToIntSeq(inputBitSeq, maxInputInt):
+    return bitSeqToIntSeq(inputBitSeq, (lambda x: eliasDeltaIotaBitSeqToInt(x, maxInputInt)))
+
+
+def intToEliasGammaFibBitSeq(inputInt, addDbgChars=False):
+    assert inputInt > 0
+    result = intToHybridCodeBitSeq(inputInt, intToFibcodeBitSeq, False, addDbgChars=addDbgChars)
+    assert result is not None
+    return result
+
 
 def eliasGammaFibBitSeqToInt(inputBitSeq):
-  result = hybridCodeBitSeqToInt(inputBitSeq,fibcodeBitSeqToInt,False)
-  assert result != None
-  return result
+    result = hybridCodeBitSeqToInt(inputBitSeq, fibcodeBitSeqToInt, False)
+    assert result is not None
+    return result
+
 
 def intSeqToEliasGammaFibBitSeq(inputIntSeq):
-  return intSeqToBitSeq(inputIntSeq,intToEliasGammaFibBitSeq)
+    return intSeqToBitSeq(inputIntSeq, intToEliasGammaFibBitSeq)
+
 
 def eliasGammaFibBitSeqToIntSeq(inputBitSeq):
-  return bitSeqToIntSeq(inputBitSeq,eliasGammaFibBitSeqToInt)
+    return bitSeqToIntSeq(inputBitSeq, eliasGammaFibBitSeqToInt)
 
 
+def intToEliasDeltaFibBitSeq(inputInt, addDbgChars=False):
+    assert inputInt > 0
+    result = intToHybridCodeBitSeq(inputInt, intToEliasGammaFibBitSeq, False, addDbgChars=addDbgChars)
+    assert result is not None
+    return result
 
-def intToEliasDeltaFibBitSeq(inputInt,addDbgChars=False):
-  assert inputInt > 0
-  result = intToHybridCodeBitSeq(inputInt,intToEliasGammaFibBitSeq,False,addDbgChars=addDbgChars)
-  assert result != None
-  return result
 
 def eliasDeltaFibBitSeqToInt(inputBitSeq):
-  result = hybridCodeBitSeqToInt(inputBitSeq,eliasGammaFibBitSeqToInt,False)
-  assert result != None
-  return result
+    result = hybridCodeBitSeqToInt(inputBitSeq, eliasGammaFibBitSeqToInt, False)
+    assert result is not None
+    return result
+
 
 def intSeqToEliasDeltaFibBitSeq(inputIntSeq):
-  return intSeqToBitSeq(inputIntSeq,intToEliasDeltaFibBitSeq)
+    return intSeqToBitSeq(inputIntSeq, intToEliasDeltaFibBitSeq)
+
 
 def eliasDeltaFibBitSeqToIntSeq(inputBitSeq):
-  return bitSeqToIntSeq(inputBitSeq,eliasDeltaFibBitSeqToInt)
-
-
-
-
-
-
-
-
-
-
-
+    return bitSeqToIntSeq(inputBitSeq, eliasDeltaFibBitSeqToInt)
 
 
 """
@@ -681,223 +709,243 @@ def compareEfficiencies(codecArr,valueGen):
         codecRecords[ci].append((testIndex,testValue,currentScores[ci]))
   return codecRecords
 """
-def getNextSizeIncreaseBounded(numberCodec,startValue,endValue):
-  assert startValue < endValue
-  startLength = len(makeArr(numberCodec.encode(startValue)))
-  endLength = len(makeArr(numberCodec.encode(endValue)))
-  assert startLength <= endLength
-  if startLength == endLength:
-    return None
-  if startValue + 1 == endValue:
-    assert startLength < endLength
-    return endValue
-  midpoint = int((startValue+endValue)/2)
-  assert midpoint not in [startValue,endValue]
-  lowerResult = getNextSizeIncreaseBounded(numberCodec,startValue,midpoint)
-  if lowerResult != None:
-    return lowerResult
-  upperResult = getNextSizeIncreaseBounded(numberCodec,midpoint,endValue)
-  return upperResult
 
 
-def getNextSizeIncreaseBoundedIterAction(numberCodec,startValue,endValue):
-  assert startValue < endValue
-  startLength = len(makeArr(numberCodec.encode(startValue)))
-  endLength = len(makeArr(numberCodec.encode(endValue)))
-  assert startLength <= endLength
-  if startLength == endLength:
-    return ("fail",None,startValue,endValue)
-  if startValue + 1 == endValue:
-    assert startLength < endLength
-    return ("finished",endValue,None,None)
-  midpoint = int((startValue+endValue)/2)
-  assert midpoint not in [startValue,endValue]
-  return ("recycle",None,startValue,midpoint)
-  #return (None,midpoint,endValue)
-
-def getNextSizeIncreaseBoundedIterative(numberCodec,startValue,endValue):
-  result = None
-  previousValues = (None,None)
-  currentValues = (startValue,endValue)
-  while True:
-    result = getNextSizeIncreaseBoundedIterAction(numberCodec,currentValues[0],currentValues[1])
-    if result[0] == "finished":
-      return result[1]
-    elif result[0] == "recycle":
-      previousValues = currentValues
-      currentValues = (result[2],result[3])
-      assert currentValues[0] < currentValues[1]
-      continue
-    elif result[0] == "fail":
-      currentValues = (result[3],previousValues[1])
-      if not currentValues[0] < currentValues[1]:
+def getNextSizeIncreaseBounded(numberCodec, startValue, endValue):
+    assert startValue < endValue
+    startLength = len(makeArr(numberCodec.encode(startValue)))
+    endLength = len(makeArr(numberCodec.encode(endValue)))
+    assert startLength <= endLength
+    if startLength == endLength:
         return None
-      if currentValues[0] == currentValues[1]:
-        return None
-      previousValues = (None,None)
-      assert currentValues[0] < currentValues[1]
-      continue
-  assert False
-
-def getNextSizeIncrease(numberCodec,startValue):
-  result = None
-  i = 0
-  try:
-    while result == None:
-      result = getNextSizeIncreaseBoundedIterative(numberCodec,startValue*(i+1),startValue*(i+2))
-      i += 1
-    if i > 2:
-      print("getNextSizeIncrease: warning: i is " + str(i) + ".")
-    return result
-  except KeyboardInterrupt:
-    raise KeyboardInterrupt("Codes.getNextSizeIncrease: i was " + str(i) + ".")
+    if startValue + 1 == endValue:
+        assert startLength < endLength
+        return endValue
+    midpoint = int((startValue + endValue) / 2)
+    assert midpoint not in [startValue, endValue]
+    lowerResult = getNextSizeIncreaseBounded(numberCodec, startValue, midpoint)
+    if lowerResult is not None:
+        return lowerResult
+    return getNextSizeIncreaseBounded(numberCodec, midpoint, endValue)
 
 
-def compareEfficienciesLinear(codecDict,valueGen):
-  previousScores = {}
-  currentScores = {}
-  codecHistory = {}
-  recordHolderHistory = []
-  for key in codecDict.keys():
-    previousScores[key] = None
-    currentScores[key] = None
-    codecHistory[key] = []
-  updateRankings = False
-  for testIndex,testValue in enumerate(valueGen):
+def getNextSizeIncreaseBoundedIterAction(numberCodec, startValue, endValue):
+    assert startValue < endValue
+    startLength = len(makeArr(numberCodec.encode(startValue)))
+    endLength = len(makeArr(numberCodec.encode(endValue)))
+    assert startLength <= endLength
+    if startLength == endLength:
+        return "fail", None, startValue, endValue
+    if startValue + 1 == endValue:
+        assert startLength < endLength
+        return "finished", endValue, None, None
+    midpoint = int((startValue + endValue) / 2)
+    assert midpoint not in [startValue, endValue]
+    return "recycle", None, startValue, midpoint
+    # return (None,midpoint,endValue)
+
+
+def getNextSizeIncreaseBoundedIterative(numberCodec, startValue, endValue):
+    previousValues = (None, None)
+    currentValues = (startValue, endValue)
+    while True:
+        result = getNextSizeIncreaseBoundedIterAction(numberCodec, currentValues[0], currentValues[1])
+        if result[0] == "finished":
+            return result[1]
+        elif result[0] == "recycle":
+            previousValues = currentValues
+            currentValues = (result[2], result[3])
+            assert currentValues[0] < currentValues[1]
+            continue
+        elif result[0] == "fail":
+            currentValues = (result[3], previousValues[1])
+            if currentValues[0] >= currentValues[1]:
+                return None
+            if currentValues[0] == currentValues[1]:
+                return None
+            previousValues = (None, None)
+            assert currentValues[0] < currentValues[1]
+            continue
+    assert False
+
+
+def getNextSizeIncrease(numberCodec, startValue):
+    result = None
+    i = 0
+    try:
+        while result is None:
+            result = getNextSizeIncreaseBoundedIterative(numberCodec, startValue * (i + 1), startValue * (i + 2))
+            i += 1
+        if i > 2:
+            print("getNextSizeIncrease: warning: i is " + str(i) + ".")
+        return result
+    except KeyboardInterrupt:
+        raise KeyboardInterrupt("Codes.getNextSizeIncrease: i was " + str(i) + ".")
+
+
+def compareEfficienciesLinear(codecDict, valueGen):
+    previousScores = {}
+    currentScores = {}
+    codecHistory = {}
+    recordHolderHistory = []
     for key in codecDict.keys():
-      testCodec = codecDict[key]
-      previousScores[key] = currentScores[key]
-      currentScores[key] = (testIndex,testValue,len(makeArr(testCodec.encode(testValue))))
-      if previousScores[key] != currentScores[key]:
-        codecHistory[key].append((testIndex,testValue,currentScores[key]))
-        updateRankings = True
-    if updateRankings:
-      updateRankings = False
-      currentBest = min(currentScores.values())
-      recordHolders = [key for key in codecDict.keys() if currentScores[key] == currentBest]
-      if len(recordHolderHistory) == 0 or recordHolders != recordHolderHistory[-1][3]:
-        recordHolderHistory.append((testIndex,testValue,currentBest,recordHolders))
-  return recordHolderHistory
+        previousScores[key] = None
+        currentScores[key] = None
+        codecHistory[key] = []
+    updateRankings = False
+    for testIndex, testValue in enumerate(valueGen):
+        for key in codecDict.keys():
+            testCodec = codecDict[key]
+            previousScores[key] = currentScores[key]
+            currentScores[key] = (
+                testIndex,
+                testValue,
+                len(makeArr(testCodec.encode(testValue))),
+            )
+            if previousScores[key] != currentScores[key]:
+                codecHistory[key].append((testIndex, testValue, currentScores[key]))
+                updateRankings = True
+        if updateRankings:
+            updateRankings = False
+            currentBest = min(currentScores.values())
+            recordHolders = [key for key in codecDict.keys() if currentScores[key] == currentBest]
+            if not recordHolderHistory or recordHolders != recordHolderHistory[-1][3]:
+                recordHolderHistory.append((testIndex, testValue, currentBest, recordHolders))
+    return recordHolderHistory
 
 
-def getEfficiencyDict(numberCodec,startValue,endValue):
-  spot = startValue
-  result = {}
-  while True:
-    spot = getNextSizeIncreaseBoundedIterative(numberCodec,spot,endValue)
-    if spot == None:
-      break
-    result[spot] = len(makeArr(numberCodec.encode(spot)))
-  return result
+def getEfficiencyDict(numberCodec, startValue, endValue):
+    spot = startValue
+    result = {}
+    while True:
+        spot = getNextSizeIncreaseBoundedIterative(numberCodec, spot, endValue)
+        if spot is None:
+            break
+        result[spot] = len(makeArr(numberCodec.encode(spot)))
+    return result
 
 
-def compareEfficiencies(codecDict,startValue,endValue):
-  codecEfficiencies = {}
-  for key in codecDict.keys():
-    codecEfficiencies[key] = getEfficiencyDict(codecDict[key],startValue,endValue)
-  events = {}
+def compareEfficiencies(codecDict, startValue, endValue):
+    codecEfficiencies = {key: getEfficiencyDict(codecDict[key], startValue, endValue) for key in codecDict.keys()}
 
-  #construct majorEvents:
-  for codecKey in codecEfficiencies.keys():
-    for numberKey in codecEfficiencies[codecKey].keys():
-      eventToAdd = (codecKey,numberKey,codecEfficiencies[codecKey][numberKey])
-      if numberKey in events.keys():
-        events[numberKey].append(eventToAdd)
-      else:
-        events[numberKey] = [eventToAdd]
+    events = {}
 
-  currentScores = dict([(key,(None,None)) for key in codecDict.keys()])
-  recordHolderHistory = [(None,None,[])]
-  #traverse majorEvents:
-  for eventKey in sorted(events.keys()): #the eventKey is the unencoded integer input value.
-    for currentEvent in events[eventKey]: #multiple events may happen at the same input value.
-      assert len(currentEvent) == 3
-      currentScores[currentEvent[0]] = (currentEvent[1],currentEvent[2]) #currentScores[name of codec] = (input value, length of code).
-      currentBest = min(item[1] for item in currentScores.values() if item[1] != None)
-      currentRecordHolders = [key for key in currentScores.keys() if currentScores[key][1] == currentBest]
-      if currentRecordHolders != recordHolderHistory[-1][2]:
-        #add new recordHolderHistory entry.
-        recordHolderHistory.append((eventKey,currentBest,currentRecordHolders))
-  return recordHolderHistory
+    # construct majorEvents:
+    for codecKey, value in codecEfficiencies.items():
+        for numberKey in value.keys():
+            eventToAdd = (codecKey, numberKey, codecEfficiencies[codecKey][numberKey])
+            if numberKey in events:
+                events[numberKey].append(eventToAdd)
+            else:
+                events[numberKey] = [eventToAdd]
 
+    currentScores = dict([(key, (None, None)) for key in codecDict.keys()])
+    recordHolderHistory = [(None, None, [])]
+    # traverse majorEvents:
+    for eventKey in sorted(events.keys()):  # the eventKey is the unencoded integer input value.
+        for currentEvent in events[eventKey]:  # multiple events may happen at the same input value.
+            assert len(currentEvent) == 3
+            currentScores[currentEvent[0]] = (
+                currentEvent[1],
+                currentEvent[2],
+            )  # currentScores[name of codec] = (input value, length of code).
+            currentBest = min(item[1] for item in currentScores.values() if item[1] is not None)
+            currentRecordHolders = [key for key in currentScores if currentScores[key][1] == currentBest]
 
-
-
-
-
-
-
-
-
+            if currentRecordHolders != recordHolderHistory[-1][2]:
+                # add new recordHolderHistory entry.
+                recordHolderHistory.append((eventKey, currentBest, currentRecordHolders))
+    return recordHolderHistory
 
 
 print("defining codecs...")
 
-codecs = {}
+codecs = {
+    "enbonacci": CodecTools.Codec(intToEnbocodeBitSeq, enbocodeBitSeqToInt, zeroSafe=False),
+    "unary": CodecTools.Codec(intToUnaryBitSeq, unaryBitSeqToInt, zeroSafe=True),
+    "eliasGamma": CodecTools.Codec(intToEliasGammaBitSeq, eliasGammaBitSeqToInt, zeroSafe=False),
+    "eliasDelta": CodecTools.Codec(intToEliasDeltaBitSeq, eliasDeltaBitSeqToInt, zeroSafe=False),
+    "eliasGammaIota": CodecTools.Codec(intToEliasGammaIotaBitSeq, eliasGammaIotaBitSeqToInt, zeroSafe=False),
+    "eliasDeltaIota": CodecTools.Codec(intToEliasDeltaIotaBitSeq, eliasDeltaIotaBitSeqToInt, zeroSafe=False),
+    "eliasGammaFib": CodecTools.Codec(intToEliasGammaFibBitSeq, eliasGammaFibBitSeqToInt, zeroSafe=False),
+    "eliasDeltaFib": CodecTools.Codec(intToEliasDeltaFibBitSeq, eliasDeltaFibBitSeqToInt, zeroSafe=False),
+    "inSeq_enbonacci": CodecTools.Codec(intSeqToEnbocodeBitSeq, enbocodeBitSeqToIntSeq, zeroSafe=False),
+    "inSeq_eliasGamma": CodecTools.Codec(intSeqToEliasGammaBitSeq, eliasGammaBitSeqToIntSeq, zeroSafe=False),
+    "inSeq_eliasDelta": CodecTools.Codec(intSeqToEliasDeltaBitSeq, eliasDeltaBitSeqToIntSeq, zeroSafe=False),
+    "inSeq_eliasGammaIota": CodecTools.Codec(intSeqToEliasGammaIotaBitSeq, eliasGammaIotaBitSeqToIntSeq, zeroSafe=False),
+    "inSeq_eliasDeltaIota": CodecTools.Codec(intSeqToEliasDeltaIotaBitSeq, eliasDeltaIotaBitSeqToIntSeq, zeroSafe=False),
+    "inSeq_eliasGammaFib": CodecTools.Codec(intSeqToEliasGammaFibBitSeq, eliasGammaFibBitSeqToIntSeq, zeroSafe=False),
+    "inSeq_eliasDeltaFib": CodecTools.Codec(intSeqToEliasDeltaFibBitSeq, eliasDeltaFibBitSeqToIntSeq, zeroSafe=False),
+}
 
-codecs["enbonacci"] = CodecTools.Codec(intToEnbocodeBitSeq,enbocodeBitSeqToInt,zeroSafe=False)
-codecs["unary"] = CodecTools.Codec(intToUnaryBitSeq,unaryBitSeqToInt,zeroSafe=True)
-codecs["eliasGamma"] = CodecTools.Codec(intToEliasGammaBitSeq,eliasGammaBitSeqToInt,zeroSafe=False)
-codecs["eliasDelta"] = CodecTools.Codec(intToEliasDeltaBitSeq,eliasDeltaBitSeqToInt,zeroSafe=False)
-codecs["eliasGammaIota"] = CodecTools.Codec(intToEliasGammaIotaBitSeq,eliasGammaIotaBitSeqToInt,zeroSafe=False)
-codecs["eliasDeltaIota"] = CodecTools.Codec(intToEliasDeltaIotaBitSeq,eliasDeltaIotaBitSeqToInt,zeroSafe=False)
-codecs["eliasGammaFib"] = CodecTools.Codec(intToEliasGammaFibBitSeq,eliasGammaFibBitSeqToInt,zeroSafe=False)
-codecs["eliasDeltaFib"] = CodecTools.Codec(intToEliasDeltaFibBitSeq,eliasDeltaFibBitSeqToInt,zeroSafe=False)
+codecs["fibonacci"] = codecs["enbonacci"].clone(extraKwargs={"order": 2})
+codecs["inSeq_fibonacci"] = codecs["inSeq_enbonacci"].clone(extraKwargs={"order": 2})
 
-codecs["inSeq_enbonacci"] = CodecTools.Codec(intSeqToEnbocodeBitSeq,enbocodeBitSeqToIntSeq,zeroSafe=False)
-codecs["inSeq_eliasGamma"] = CodecTools.Codec(intSeqToEliasGammaBitSeq,eliasGammaBitSeqToIntSeq,zeroSafe=False)
-codecs["inSeq_eliasDelta"] = CodecTools.Codec(intSeqToEliasDeltaBitSeq,eliasDeltaBitSeqToIntSeq,zeroSafe=False)
-codecs["inSeq_eliasGammaIota"] = CodecTools.Codec(intSeqToEliasGammaIotaBitSeq,eliasGammaIotaBitSeqToIntSeq,zeroSafe=False)
-codecs["inSeq_eliasDeltaIota"] = CodecTools.Codec(intSeqToEliasDeltaIotaBitSeq,eliasDeltaIotaBitSeqToIntSeq,zeroSafe=False)
-codecs["inSeq_eliasGammaFib"] = CodecTools.Codec(intSeqToEliasGammaFibBitSeq,eliasGammaFibBitSeqToIntSeq,zeroSafe=False)
-codecs["inSeq_eliasDeltaFib"] = CodecTools.Codec(intSeqToEliasDeltaFibBitSeq,eliasDeltaFibBitSeqToIntSeq,zeroSafe=False)
+FIBONACCI_ORDER_NICKNAMES = {
+    "tribonacci": 3,
+    "tetranacci": 4,
+    "pentanacci": 5,
+    "hexanacci": 6,
+    "heptanacci": 7,
+    "octanacci": 8,
+    "enneanacci": 9,
+}
 
-codecs["fibonacci"] = codecs["enbonacci"].clone(extraKwargs={"order":2})
-codecs["inSeq_fibonacci"] = codecs["inSeq_enbonacci"].clone(extraKwargs={"order":2})
+for orderName, order in FIBONACCI_ORDER_NICKNAMES.items():
+    codecs[orderName] = codecs["enbonacci"].clone(extraKwargs={"order": order})
+    codecs["inSeq_" + orderName] = codecs["inSeq_enbonacci"].clone(extraKwargs={"order": order})
 
-FIBONACCI_ORDER_NICKNAMES = {"tribonacci":3,"tetranacci":4,"pentanacci":5,"hexanacci":6,"heptanacci":7,"octanacci":8,"enneanacci":9}
-
-for orderName,order in FIBONACCI_ORDER_NICKNAMES.items():
-  codecs[orderName] = codecs["enbonacci"].clone(extraKwargs={"order":order})
-  codecs["inSeq_"+orderName] = codecs["inSeq_enbonacci"].clone(extraKwargs={"order":order})
-
-#fibonacci coding is more efficient than eliasGamma coding for numbers 16..(10**60), so it's likely that eliasDeltaFib is more efficient than eliasDelta for numbers (2**15)..(2**(10**60-1)).
-#eliasDelta coding is more efficient than fibonacci coding for numbers 317811..(10**60).
-#it seems like eliasDeltaFib must be more efficient than EliasDelta eventually, but they trade blows all the way up to 10**606, with EDF seemingly being the only one able to break the tie.
+# fibonacci coding is more efficient than eliasGamma coding for numbers 16..(10**60), so it's likely that eliasDeltaFib
+# is more efficient than eliasDelta for numbers (2**15)..(2**(10**60-1)).
+# eliasDelta coding is more efficient than fibonacci coding for numbers 317811..(10**60).
+# it seems like eliasDeltaFib must be more efficient than EliasDelta eventually, but they trade blows all the way up
+# to 10**606, with EDF seemingly being the only one able to break the tie.
 
 
 print("performing over-eating tests...")
 
-#the following 3 tests check to make sure functions that accept generators as arguments do not overeat from those generators.
+# the following 3 tests check to make sure functions that accept generators as arguments do not overeat from those
+# generators.
 testGen = makeGen(CodecTools.bitSeqToStrCodec.decode("11011"))
-assert enbocodeBitSeqToInt(testGen,order=2) == 1
-assert makeArr(testGen) == [0,1,1]
+assert enbocodeBitSeqToInt(testGen, order=2) == 1
+assert makeArr(testGen) == [0, 1, 1]
 
 testGen = makeGen(CodecTools.bitSeqToStrCodec.decode("10110011"))
-assert enbocodeBitSeqToInt(testGen,order=2) == 4
-assert makeArr(testGen) == [0,0,1,1]
+assert enbocodeBitSeqToInt(testGen, order=2) == 4
+assert makeArr(testGen) == [0, 0, 1, 1]
 
-testGen = makeGen([0,0,0,1,0,0,1])
+testGen = makeGen([0, 0, 0, 1, 0, 0, 1])
 assert unaryBitSeqToInt(testGen) == 3
-assert makeArr(testGen) == [0,0,1]
+assert makeArr(testGen) == [0, 0, 1]
 
-testGen = makeGen([0,0,1,1,1,0,0,1])
+testGen = makeGen([0, 0, 1, 1, 1, 0, 0, 1])
 assert eliasGammaBitSeqToInt(testGen) == 7
-assert makeArr(testGen) == [0,0,1]
-
-
+assert makeArr(testGen) == [0, 0, 1]
 
 print("performing full codec tests...")
 
-for testCodecName in ["fibonacci","unary","eliasGamma","eliasDelta","eliasGammaFib","eliasDeltaFib"]:
-  print("testing " + testCodecName + "...")
-  for testNum in [1,5,10,255,257,65535,65537,999999]:
-    assert CodecTools.roundTripTest(codecs[testCodecName],testNum)
+for testCodecName in [
+    "fibonacci",
+    "unary",
+    "eliasGamma",
+    "eliasDelta",
+    "eliasGammaFib",
+    "eliasDeltaFib",
+]:
+    print("testing " + testCodecName + "...")
+    for testNum in [1, 5, 10, 255, 257, 65535, 65537, 999999]:
+        assert CodecTools.roundTripTest(codecs[testCodecName], testNum)
 
-for testCodecName in ["inSeq_fibonacci","inSeq_eliasGamma","inSeq_eliasDelta","inSeq_eliasGammaFib","inSeq_eliasDeltaFib"]:
-  print("testing " + testCodecName + "...")
-  testArr = [1,2,3,4,5,100,1000,1000000,1,1000,1,100,1,5,4,3,2,1]
-  assert CodecTools.roundTripTest(codecs[testCodecName],testArr)
+for testCodecName in [
+    "inSeq_fibonacci",
+    "inSeq_eliasGamma",
+    "inSeq_eliasDelta",
+    "inSeq_eliasGammaFib",
+    "inSeq_eliasDeltaFib",
+]:
+    print("testing " + testCodecName + "...")
+    testArr = [1, 2, 3, 4, 5, 100, 1000, 1000000, 1, 1000, 1, 100, 1, 5, 4, 3, 2, 1]
+    assert CodecTools.roundTripTest(codecs[testCodecName], testArr)
 
 """
 for testCodecName in FIBONACCI_ORDER_NICKNAMES.keys():
@@ -910,9 +958,9 @@ for testCodecName in FIBONACCI_ORDER_NICKNAMES.keys():
   print((testCodecName,testArr,CodecTools.roundTripTest(codecs[testCodecName],testArr)))
 """
 
-
 print("performing tests of Iota codings...")
 
-assert CodecTools.roundTripTest(codecs["inSeq_eliasGammaIota"].clone(extraKwargs={"maxInputInt":15}),[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])
-
-
+assert CodecTools.roundTripTest(
+    codecs["inSeq_eliasGammaIota"].clone(extraKwargs={"maxInputInt": 15}),
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 121
+target-version = ['py36', 'py37', 'py38']
+experimental_string_processing = true
+
+[tool.isort]
+profile = 'black'
+multi_line_output = 3


### PR DESCRIPTION
Hi,

I added some pre-commit hooks.  Some people like them, some don't, so let me know if you do!  TLDR:  If you install pre-commit https://pre-commit.com/, then run ```pre-commit install``` in your terminal at the top of the repo, from that point on, anytime you commit, it will automatically do a bunch of things for you.  You can also ```git add . && pre-commit run``` if you want to just run it without committing.  

Sample output when committing
![image](https://user-images.githubusercontent.com/5382669/125953438-3ac76ceb-645e-4da3-b1df-cb0aaf8a9fe1.png)


The config for it is in the file .pre-commit-config.  I have it set to automatically sort imports, lint, format using black (really nice formatter), check for merge conflicts, detect if credentials are stored, and ensure each file has an extra line at the end.

I also added a file named .flake8 (for the linter, wanted to make the line length maximum longer, set to 121, totally preference).
.isort.cfg is the config for isort, which sorts your imports automatically
pyproject.toml has the config for black, the formatter, and I'm just telling it a max line length of 121 as well.

pre-commit will only run against files that you've changed, unless you intentionally want to run it against everything ```pre-commit run --all-files```

I then formatted/linted/tweaked CERWaves.py, CodecTools.py, and Codes.py, that way you can see if you like how it looks or not.  (And some little fixes, like there was a check to see if a variable is an int or long, and removed the long).  Python3 replaced int essentially WITH long, so there is no "long" now.  That sort of thing.  None of the changes should break anything, but don't trust me on that :). 

Some of the other things were like, getting rid of ```close()``` by using ```with:```, and using ```yield from``` to replace for loops that were just returning the items inside.  I hope that's ok!